### PR TITLE
Fix Windows build on SDL2 branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,13 @@ project(3dzavr_test)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
 add_executable(${CMAKE_PROJECT_NAME} main.cpp)
 
+find_package(SDL2 CONFIG COMPONENTS SDL2main)
+if(TARGET SDL2::SDL2main)
+    target_link_libraries(3dzavr_test PRIVATE SDL2::SDL2main)
+else()
+    target_compile_definitions(3dzavr_test PRIVATE SDL_MAIN_HANDLED)
+endif()
+
 # include engine into our project
 add_subdirectory(engine)
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC 3DZAVR)

--- a/engine/io/Keyboard.cpp
+++ b/engine/io/Keyboard.cpp
@@ -26,8 +26,10 @@ bool Keyboard::isKeyPressed(SDL_Keycode key) {
         return false;
     }
 
-    if(_instance->_keys.find(key)->second) {
-        return _instance->_keys[key];
+    auto it = _instance->_keys.find(key);
+
+    if (it != _instance->_keys.end()) {
+        return it->second;
     }
 
     return false;

--- a/engine/io/Screen.cpp
+++ b/engine/io/Screen.cpp
@@ -32,7 +32,7 @@ void Screen::open(uint16_t screenWidth, uint16_t screenHeight, const std::string
 
     SDL_SetRenderDrawColor(_renderer, background.r(), background.g(), background.b(), background.a());
     SDL_RenderClear(_renderer);
-
+    SDL_SetRelativeMouseMode(SDL_TRUE);
     SDL_ShowCursor(SDL_DISABLE);
 
     initDepthBuffer();
@@ -75,7 +75,6 @@ void Screen::display() {
     if(_isOpen) {
         SDL_SetRenderDrawColor(_renderer, _background.r(), _background.g(), _background.b(), _background.a());
         SDL_RenderPresent(_renderer);
-        SDL_WarpMouseInWindow(_window, (float)width()/2*Consts::SCREEN_SCALE, (float)height()/2*Consts::SCREEN_SCALE);
     }
 }
 

--- a/engine/objects/props/Material.h
+++ b/engine/objects/props/Material.h
@@ -36,7 +36,7 @@ private:
     // ...
 
     Color _ambient, _diffuse, _specular;
-    u_int16_t _illum;
+    uint16_t _illum;
 
 public:
     Material(const MaterialTag& tag,
@@ -44,14 +44,14 @@ public:
              const Color& ambient,
              const Color& diffuse,
              const Color& specular,
-             u_int8_t illum) :
+             uint8_t illum) :
              _tag(tag), _texture(texture), _ambient(ambient), _diffuse(diffuse),
              _specular(specular), _illum(illum) {};
 
     [[nodiscard]] Color ambient() const { return _ambient; }
     [[nodiscard]] Color diffuse() const { return _diffuse; }
     [[nodiscard]] Color specular() const { return _specular; }
-    [[nodiscard]] u_int8_t illum() const { return _illum; }
+    [[nodiscard]] uint8_t illum() const { return _illum; }
 
     [[nodiscard]] std::shared_ptr<Texture> texture() const {return _texture;}
 

--- a/engine/objects/props/Texture.h
+++ b/engine/objects/props/Texture.h
@@ -25,8 +25,8 @@ public:
     // For resampling
     [[nodiscard]] Color get_pixel_from_UV(const Vec2D& uv, double area) const;
 
-    [[nodiscard]] u_int16_t width() const {return _texture.front()->width(); }
-    [[nodiscard]] u_int16_t height() const {return _texture.front()->height(); }
+    [[nodiscard]] uint16_t width() const {return _texture.front()->width(); }
+    [[nodiscard]] uint16_t height() const {return _texture.front()->height(); }
 };
 
 

--- a/engine/utils/Font.cpp
+++ b/engine/utils/Font.cpp
@@ -16,7 +16,7 @@ Font::Font(const FontTag& tag, const FilePath& fileName) : _tag(tag), _fileName(
 
 }
 
-TTF_Font* Font::getFont(u_int16_t fontSize) {
+TTF_Font* Font::getFont(uint16_t fontSize) {
 
     if(_fonts.contains(fontSize) && _fonts[fontSize]) {
         return _fonts[fontSize];

--- a/engine/utils/Font.h
+++ b/engine/utils/Font.h
@@ -36,11 +36,11 @@ private:
     const FilePath _fileName;
 
     // Here we store this font for different fontsize
-    std::map<u_int16_t, TTF_Font*> _fonts;
+    std::map<uint16_t, TTF_Font*> _fonts;
 public:
     Font(const FontTag& tag, const FilePath& fileName);
 
-    TTF_Font* getFont(u_int16_t fontSize=14);
+    TTF_Font* getFont(uint16_t fontSize=14);
 
     ~Font();
 };

--- a/engine/utils/ResourceManager.cpp
+++ b/engine/utils/ResourceManager.cpp
@@ -2,6 +2,7 @@
 // Created by Neirokan on 09.05.2020
 //
 
+#include <algorithm>
 #include <sstream>
 #include <fstream>
 #include <memory>
@@ -39,7 +40,7 @@ std::map<MaterialTag, std::shared_ptr<Material>> ResourceManager::loadMaterials(
     std::string matName;
     std::shared_ptr<Texture> texture = nullptr;
     Color ambient, diffuse, specular;
-    u_int16_t illum;
+    uint16_t illum;
     bool readAmbient = false, readDiffuse = false, readSpecular = false, readIllum = false;
 
     // On each step we will check did we read all the information to be able to create a new material

--- a/main.cpp
+++ b/main.cpp
@@ -113,4 +113,5 @@ public:
 int main(int argc, char *argv[]) {
     Test test;
     test.create();
+    return 0;
 }


### PR DESCRIPTION
- Link SDL2::SDL2main when possible
- replace all `u_int` with standard `uint`
- add missing include

With these fixes, it now builds successfully using vcpkg and MSVC or MinGW.


Should be compatible with https://github.com/vectozavr/3dzavr/pull/12 (or trivial to resolve conflicts).