### PR TITLE
SDL resources fix

### DIFF
--- a/engine/io/Image.cpp
+++ b/engine/io/Image.cpp
@@ -12,13 +12,13 @@ Image::Image(uint16_t width, uint16_t height) : _width(width), _height(height), 
     if(width != 0 && height != 0) {
         _data = new png_byte[_height * _width * 4];
     } else {
-        _valid = false;
+        invalidate();
     }
 }
 
 Image::Image(Image&& other) noexcept : _width(other._width), _height(other._height), _valid(other._valid), _data(other._data) {
-    other._valid = false;
     other._data = nullptr;
+    other.invalidate();
 }
 
 Image::Image(const FilePath &filename) {
@@ -26,7 +26,7 @@ Image::Image(const FilePath &filename) {
     FILE *fp = fopen(filename.str().c_str(), "rb");
 
     if (!fp) {
-        _valid = false;
+        invalidate();
         return;
     }
 
@@ -94,21 +94,24 @@ Image::Image(const FilePath &filename) {
 }
 
 Image::~Image() {
-    // deallocate memory
+    invalidate();
+}
+
+void Image::invalidate() {
     if (_data != nullptr) {
         delete[] _data;
     }
     _data = nullptr;
     _valid = false;
+    _width = _height = 0;
 }
 
 Image& Image::operator=(Image&& other) noexcept {
-    _valid = other._valid;
-    other._valid = false;
-
     if (_data != nullptr) delete[] _data;
+    _valid = other._valid;
     _data = other._data;
     other._data = nullptr;
+    other.invalidate();
     return *this;
 }
 

--- a/engine/io/Image.h
+++ b/engine/io/Image.h
@@ -25,6 +25,8 @@ private:
     png_bytep _data = nullptr;
 
     bool _valid = false;
+
+    void invalidate();
 public:
     explicit Image(uint16_t width = Consts::STANDARD_SCREEN_WIDTH, uint16_t height = Consts::STANDARD_SCREEN_HEIGHT);
     explicit Image(const FilePath &filename);

--- a/resources/obj/cars/car3/Car3.mtl
+++ b/resources/obj/cars/car3/Car3.mtl
@@ -10,4 +10,4 @@ Ke 0.000000 0.000000 0.000000
 Ni 1.500000
 d 1.000000
 illum 1
-map_Kd Car3.png
+map_Kd car3.png


### PR DESCRIPTION
- fix car3 material (linux is case sensitive, so...)
- reset all fields on invalid image to prevent segmentation fault when down sampling