### PR TITLE
Small SDL fixes

### DIFF
--- a/engine/objects/Object.h
+++ b/engine/objects/Object.h
@@ -138,7 +138,7 @@ public:
     [[nodiscard]] Matrix4x4 invModel() const { return Matrix4x4::View(model()); }
     [[nodiscard]] Matrix4x4 fullInvModel() const { return Matrix4x4::View(fullModel()); }
 
-    ~Object();
+    virtual ~Object();
 };
 
-#endif //MINECRAFT_3DZAVR_OBJECT_H
+#endif //ENGINE_OBJECT_H

--- a/main.cpp
+++ b/main.cpp
@@ -88,22 +88,24 @@ private:
             selectedObject.reset();
         }
 
-        // object scale x:
-        if(Keyboard::isKeyPressed(SDLK_UP) && objSelected) {
-            selectedObject->scaleInside(Vec3D(1 + Time::deltaTime(), 1, 1));
-        }
-        // object scale y:
-        if(Keyboard::isKeyPressed(SDLK_DOWN) && objSelected) {
-            selectedObject->scaleInside(Vec3D(1, 1 + Time::deltaTime(), 1));
-        }
-        // object scale z:
-        if(Keyboard::isKeyPressed(SDLK_LEFT) && objSelected) {
-            selectedObject->scaleInside(Vec3D(1, 1, 1 + Time::deltaTime()));
-        }
+        if (selectedObject) {
+            // object scale x:
+            if (Keyboard::isKeyPressed(SDLK_UP)) {
+                selectedObject->scaleInside(Vec3D(1 + Time::deltaTime(), 1, 1));
+            }
+            // object scale y:
+            if (Keyboard::isKeyPressed(SDLK_DOWN)) {
+                selectedObject->scaleInside(Vec3D(1, 1 + Time::deltaTime(), 1));
+            }
+            // object scale z:
+            if (Keyboard::isKeyPressed(SDLK_LEFT)) {
+                selectedObject->scaleInside(Vec3D(1, 1, 1 + Time::deltaTime()));
+            }
 
-        // undo transformations
-        if(Keyboard::isKeyPressed(SDLK_u) && objSelected) {
-            selectedObject->transform(selectedObject->invModel());
+            // undo transformations
+            if (Keyboard::isKeyPressed(SDLK_u)) {
+                selectedObject->transform(selectedObject->invModel());
+            }
         }
 
         if(Keyboard::isKeyTapped(SDLK_TAB)) {


### PR DESCRIPTION
- fix Object inheritance
- separate objects when parsing .obj files only when new object/group/material starts
- add one shared condition to controls in 3dzavr_test