### PR TITLE
SDL optimizations

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(
         objects/props/Material.h
         objects/props/Material.cpp
 
+        objects/geometry/Bounds.h
         objects/geometry/Triangle.h
         objects/geometry/Triangle.cpp
         objects/geometry/Plane.h

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -99,6 +99,17 @@ target_include_directories(3DZAVR PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/)
 
 include_directories(/usr/local/include)
 
+include(CheckIPOSupported)
+check_ipo_supported(RESULT lto_supported OUTPUT lto_error)
+
+if(lto_supported)
+    # I don't think you want to make debug builds harder to debug and longer to build
+    set_property(TARGET 3DZAVR PROPERTY INTERPROCEDURAL_OPTIMIZATION_DEBUG FALSE)
+    set_property(TARGET 3DZAVR PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+else()
+    message(WARNING "CMake can't enable LTO optimizations for your current compiler.\n${lto_error}")
+endif()
+
 # LibPNG library
 find_package(PNG REQUIRED)
 include_directories(${PNG_INCLUDE_DIR})

--- a/engine/Engine.cpp
+++ b/engine/Engine.cpp
@@ -106,6 +106,7 @@ void Engine::create(uint16_t screenWidth, uint16_t screenHeight, const Color& ba
             Time::stopTimer("d collisions");
         }
 
+        camera->updateFrustum();
         projectAndDrawGroup(*world->objects());
 
         Time::stopTimer("d projections");

--- a/engine/Engine.h
+++ b/engine/Engine.h
@@ -26,7 +26,7 @@
 class Engine {
 private:
     bool _updateWorld = true;
-    void projectAndDrawGroup(std::shared_ptr<Group> group) const;
+    void projectAndDrawGroup(const Group& group) const;
 
     // For debug purposes
     bool _showDebugInfo = Consts::SHOW_DEBUG_INFO;

--- a/engine/objects/Camera.cpp
+++ b/engine/objects/Camera.cpp
@@ -8,27 +8,24 @@
 #include "Camera.h"
 #include "Consts.h"
 
-std::vector<std::pair<std::shared_ptr<Triangle>, std::shared_ptr<Material>>> Camera::project(std::shared_ptr<Mesh> mesh) {
+std::vector<Triangle> Camera::project(const Mesh& mesh) {
 
-    std::vector<std::pair<std::shared_ptr<Triangle>, std::shared_ptr<Material>>> result{};
+    std::vector<Triangle> result{};
 
     if (!_ready) {
         Log::log("Camera::project(): cannot project _tris without camera initialization ( Camera::setup() ) ");
         return result;
     }
 
-    if (!mesh->isVisible()) {
+    if (!mesh.isVisible()) {
         return result;
     }
 
     // Model transform matrix: translate _tris in the origin of body.
-    Matrix4x4 M = mesh->fullModel();
+    Matrix4x4 M = mesh.fullModel();
     Matrix4x4 V = fullInvModel();
 
-    // We don't want to waste time re-allocating memory every time
-    std::vector<Triangle> clippedTriangles, tempBuffer;
-
-    for (auto &t : mesh->triangles()) {
+    for (auto &t : mesh.triangles()) {
 
         Triangle MTriangle = t * M;
 
@@ -41,41 +38,41 @@ std::vector<std::pair<std::shared_ptr<Triangle>, std::shared_ptr<Material>>> Cam
         Triangle VMTriangle = MTriangle * V;
 
         // It needs to be cleared because it's reused through iterations. Usually it doesn't free memory.
-        clippedTriangles.clear();
-        tempBuffer.clear();
+        _clippedTriangles.clear();
+        _tempBuffer.clear();
 
         // In the beginning we need to translate triangle from world coordinate to our camera system:
         // After that we apply clipping for all planes from _clipPlanes
-        clippedTriangles.emplace_back(VMTriangle);
+        _clippedTriangles.emplace_back(VMTriangle);
         for (auto &plane : _clipPlanes) {
-            while (!clippedTriangles.empty()) {
-                stack_vector<Triangle, 2> clipResult = plane->clip(clippedTriangles.back());
-                clippedTriangles.pop_back();
+            while (!_clippedTriangles.empty()) {
+                stack_vector<Triangle, 2> clipResult = plane.clip(_clippedTriangles.back());
+                _clippedTriangles.pop_back();
                 for (auto &i : clipResult) {
-                    tempBuffer.emplace_back(i);
+                    _tempBuffer.emplace_back(i);
                 }
             }
-            clippedTriangles.swap(tempBuffer);
+            _clippedTriangles.swap(_tempBuffer);
         }
 
-        for (auto &clipped : clippedTriangles) {
-            // Finally its time to project our clipped colored drawTriangle from 3D -> 2D
-            // and transform it's coordinate to screen space (in pixels):
+        for (auto &clipped : _clippedTriangles) {
+            // Finally it's time to project our clipped colored drawTriangle from 3D -> 2D
+            // and transform its coordinate to screen space (in pixels):
             Triangle clippedProjected = clipped * _SP;
             auto clippedTexCoord = clippedProjected.textureCoordinates();
 
-            Triangle clippedProjectedNormalized = Triangle({clippedProjected[0] / clippedProjected[0].w(),
-                                                            clippedProjected[1] / clippedProjected[1].w(),
-                                                            clippedProjected[2] / clippedProjected[2].w()},
-                                                           {clippedTexCoord[0] / clippedProjected[0].w(),
-                                                            clippedTexCoord[1] / clippedProjected[1].w(),
-                                                            clippedTexCoord[2] / clippedProjected[2].w()});
-
-            auto material = mesh->getMaterial();
-            auto tri = std::make_shared<Triangle>(clippedProjectedNormalized);
-            std::pair<std::shared_ptr<Triangle>, std::shared_ptr<Material>> pair(tri, material);
-
-            result.emplace_back(pair);
+            result.emplace_back(
+                std::array<Vec4D, 3>{
+                    clippedProjected[0] / clippedProjected[0].w(),
+                    clippedProjected[1] / clippedProjected[1].w(),
+                    clippedProjected[2] / clippedProjected[2].w()
+                },
+                std::array<Vec3D, 3>{
+                    clippedTexCoord[0] / clippedProjected[0].w(),
+                    clippedTexCoord[1] / clippedProjected[1].w(),
+                    clippedTexCoord[2] / clippedProjected[2].w()
+                }
+            );
         }
     }
 
@@ -93,15 +90,19 @@ void Camera::setup(int width, int height, double fov, double ZNear, double ZFar)
 
     // This is planes for clipping _tris.
     // Motivation: we are not interested in _tris that we cannot see.
-    _clipPlanes.emplace_back(std::make_shared<Plane>(Vec3D{0, 0, 1}, Vec3D{0, 0, ZNear}, ObjectTag("near"))); // near plane
-    _clipPlanes.emplace_back(std::make_shared<Plane>(Vec3D{0, 0, -1}, Vec3D{0, 0, ZFar}, ObjectTag("far"))); // far plane
+    _clipPlanes.emplace_back(Vec3D{0, 0, 1}, Vec3D{0, 0, ZNear}); // near plane
+    _clipPlanes.emplace_back(Vec3D{0, 0, -1}, Vec3D{0, 0, ZFar}); // far plane
 
     double thetta1 = Consts::PI * fov * 0.5 / 180.0;
     double thetta2 = atan(_aspect * tan(thetta1));
-    _clipPlanes.emplace_back(std::make_shared<Plane>(Vec3D{-cos(thetta2), 0, sin(thetta2)}, Vec3D{0, 0, 0}, ObjectTag("left"))); // left plane
-    _clipPlanes.emplace_back(std::make_shared<Plane>(Vec3D{cos(thetta2), 0, sin(thetta2)}, Vec3D{0, 0, 0}, ObjectTag("right"))); // right plane
-    _clipPlanes.emplace_back(std::make_shared<Plane>(Vec3D{0, cos(thetta1), sin(thetta1)}, Vec3D{0, 0, 0}, ObjectTag("down"))); // down plane
-    _clipPlanes.emplace_back(std::make_shared<Plane>(Vec3D{0, -cos(thetta1), sin(thetta1)}, Vec3D{0, 0, 0}, ObjectTag("up"))); // up plane
+    _clipPlanes.emplace_back(Vec3D{-cos(thetta2), 0, sin(thetta2)}, Vec3D{0, 0, 0}); // left plane
+    _clipPlanes.emplace_back(Vec3D{cos(thetta2), 0, sin(thetta2)}, Vec3D{0, 0, 0}); // right plane
+    _clipPlanes.emplace_back(Vec3D{0, cos(thetta1), sin(thetta1)}, Vec3D{0, 0, 0}); // down plane
+    _clipPlanes.emplace_back(Vec3D{0, -cos(thetta1), sin(thetta1)}, Vec3D{0, 0, 0}); // up plane
+
+    // The capacity is chosen simply by a small runtime test.
+    _clippedTriangles.reserve(12);
+    _tempBuffer.reserve(12);
 
     _ready = true;
     Log::log("Camera::init(): camera successfully initialized.");

--- a/engine/objects/Camera.cpp
+++ b/engine/objects/Camera.cpp
@@ -22,12 +22,12 @@ std::vector<Triangle> Camera::project(const Mesh& mesh) {
     }
 
     // Model transform matrix: translate _tris in the origin of body.
-    Matrix4x4 M = mesh.fullModel();
-    Matrix4x4 V = fullInvModel();
+    Matrix4x4 objectToWorld = mesh.fullModel();
+    Matrix4x4 worldToScreen = _SP * fullInvModel();
 
     for (auto &t : mesh.triangles()) {
 
-        Triangle MTriangle = t * M;
+        Triangle MTriangle = t * objectToWorld;
 
         double dot = MTriangle.norm().dot((Vec3D(MTriangle.position()) - position()).normalized());
 
@@ -35,15 +35,13 @@ std::vector<Triangle> Camera::project(const Mesh& mesh) {
             continue;
         }
 
-        Triangle VMTriangle = MTriangle * V;
-
         // It needs to be cleared because it's reused through iterations. Usually it doesn't free memory.
         _clippedTriangles.clear();
         _tempBuffer.clear();
 
-        // In the beginning we need to translate triangle from world coordinate to our camera system:
+        // In the beginning we need to translate triangle from object local coordinate to world coordinates:
         // After that we apply clipping for all planes from _clipPlanes
-        _clippedTriangles.emplace_back(VMTriangle);
+        _clippedTriangles.emplace_back(MTriangle);
         for (auto &plane : _clipPlanes) {
             while (!_clippedTriangles.empty()) {
                 stack_vector<Triangle, 2> clipResult = plane.clip(_clippedTriangles.back());
@@ -58,7 +56,7 @@ std::vector<Triangle> Camera::project(const Mesh& mesh) {
         for (auto &clipped : _clippedTriangles) {
             // Finally it's time to project our clipped colored drawTriangle from 3D -> 2D
             // and transform its coordinate to screen space (in pixels):
-            Triangle clippedProjected = clipped * _SP;
+            Triangle clippedProjected = clipped * worldToScreen;
             auto clippedTexCoord = clippedProjected.textureCoordinates();
 
             result.emplace_back(
@@ -82,25 +80,18 @@ std::vector<Triangle> Camera::project(const Mesh& mesh) {
 void Camera::setup(int width, int height, double fov, double ZNear, double ZFar) {
     // We need to init camera only after creation or changing width, height, fov, ZNear or ZFar.
     // Because here we calculate matrix that does not change during the motion of _objects or camera
+    _znear = ZNear;
+    _zfar = ZFar;
+    _fov = fov;
     _aspect = (double) width / (double) height;
     Matrix4x4 P = Matrix4x4::Projection(fov, _aspect, ZNear, ZFar);
     Matrix4x4 S = Matrix4x4::ScreenSpace(width, height);
 
     _SP = S * P; // screen-space-projections matrix
 
-    // This is planes for clipping _tris.
-    // Motivation: we are not interested in _tris that we cannot see.
-    _clipPlanes.emplace_back(Vec3D{0, 0, 1}, Vec3D{0, 0, ZNear}); // near plane
-    _clipPlanes.emplace_back(Vec3D{0, 0, -1}, Vec3D{0, 0, ZFar}); // far plane
+    _clipPlanes.reserve(6);
 
-    double thetta1 = Consts::PI * fov * 0.5 / 180.0;
-    double thetta2 = atan(_aspect * tan(thetta1));
-    _clipPlanes.emplace_back(Vec3D{-cos(thetta2), 0, sin(thetta2)}, Vec3D{0, 0, 0}); // left plane
-    _clipPlanes.emplace_back(Vec3D{cos(thetta2), 0, sin(thetta2)}, Vec3D{0, 0, 0}); // right plane
-    _clipPlanes.emplace_back(Vec3D{0, cos(thetta1), sin(thetta1)}, Vec3D{0, 0, 0}); // down plane
-    _clipPlanes.emplace_back(Vec3D{0, -cos(thetta1), sin(thetta1)}, Vec3D{0, 0, 0}); // up plane
-
-    // The capacity is chosen simply by a small runtime test.
+    // The capacity is chosen simply by a small runtime test (though with proper clipping it should be 7 at most).
     _clippedTriangles.reserve(12);
     _tempBuffer.reserve(12);
 
@@ -108,6 +99,29 @@ void Camera::setup(int width, int height, double fov, double ZNear, double ZFar)
     Log::log("Camera::init(): camera successfully initialized.");
 }
 
-Camera::~Camera() {
+void Camera::updateFrustum() {
     _clipPlanes.clear();
+    Matrix4x4 cameraModel = fullModel();
+
+    Vec3D pos = this->position();
+    Vec3D forward = this->lookAt();
+    Vec3D left = this->left();
+    Vec3D up = this->up();
+
+    const double halfVSide = _zfar * tan(Consts::PI * _fov * 0.5 / 180.0);
+    const double halfHSide = halfVSide * _aspect;
+    const Vec3D frontMultFar = forward * _zfar;
+
+    // This is planes for clipping _tris.
+    // Motivation: we are not interested in _tris that we cannot see.
+    _clipPlanes.emplace_back(forward, pos + forward * _znear);                  // near plane
+    _clipPlanes.emplace_back(-forward, pos + frontMultFar);                     // far plane
+    _clipPlanes.emplace_back((frontMultFar + left * halfHSide).cross(up), pos); // left plane
+    _clipPlanes.emplace_back(up.cross(frontMultFar - left * halfHSide), pos);   // right plane
+    _clipPlanes.emplace_back((frontMultFar - up * halfVSide).cross(left), pos); // bottom plane
+    _clipPlanes.emplace_back(left.cross(frontMultFar + up * halfVSide), pos);   // top plane
+    // Prevent transparent pixels at the edge of the screen
+    for (size_t i = 2; i < _clipPlanes.size(); i++) {
+        _clipPlanes[i].offset -= Consts::EPS;
+    }
 }

--- a/engine/objects/Camera.h
+++ b/engine/objects/Camera.h
@@ -12,9 +12,12 @@
 
 class Camera final : public Object {
 private:
-    std::vector<std::shared_ptr<Plane>> _clipPlanes{};
+    std::vector<Plane> _clipPlanes;
     bool _ready = false;
     double _aspect = 0;
+    // Internal variables to reduce allocations
+    std::vector<Triangle> _clippedTriangles;
+    std::vector<Triangle> _tempBuffer;
 
     Matrix4x4 _SP;
 public:
@@ -24,10 +27,10 @@ public:
 
     void setup(int width, int height, double fov = 90.0, double ZNear = 0.1, double ZFar = 5000.0);
 
-    std::vector<std::pair<std::shared_ptr<Triangle>, std::shared_ptr<Material>>> project(std::shared_ptr<Mesh> mesh);
+    std::vector<Triangle> project(const Mesh& mesh);
 
     ~Camera();
 };
 
 
-#endif //INC_3DZAVR_CAMERA_H
+#endif //ENGINE_CAMERA_H

--- a/engine/objects/Camera.h
+++ b/engine/objects/Camera.h
@@ -13,6 +13,9 @@
 class Camera final : public Object {
 private:
     std::vector<Plane> _clipPlanes;
+    double _znear = 0;
+    double _zfar = 0;
+    double _fov = 0;
     bool _ready = false;
     double _aspect = 0;
     // Internal variables to reduce allocations
@@ -27,9 +30,9 @@ public:
 
     void setup(int width, int height, double fov = 90.0, double ZNear = 0.1, double ZFar = 5000.0);
 
-    std::vector<Triangle> project(const Mesh& mesh);
+    void updateFrustum();
 
-    ~Camera();
+    std::vector<Triangle> project(const Mesh& mesh);
 };
 
 

--- a/engine/objects/Group.h
+++ b/engine/objects/Group.h
@@ -2,8 +2,8 @@
 // Created by Иван Ильин on 24/01/2024.
 //
 
-#ifndef INC_3DZAVR_TEST_GROUP_H
-#define INC_3DZAVR_TEST_GROUP_H
+#ifndef ENGINE_GROUP_H
+#define ENGINE_GROUP_H
 
 #include <objects/Object.h>
 
@@ -33,6 +33,9 @@ public:
     std::map<ObjectTag, std::shared_ptr<Object>>::iterator begin() { return _objects.begin(); }
     std::map<ObjectTag, std::shared_ptr<Object>>::iterator end() { return _objects.end(); }
 
+    std::map<ObjectTag, std::shared_ptr<Object>>::const_iterator begin() const { return _objects.begin(); }
+    std::map<ObjectTag, std::shared_ptr<Object>>::const_iterator end() const { return _objects.end(); }
+
     [[nodiscard]] IntersectionInformation intersect(const Vec3D &from, const Vec3D &to) override;
     [[nodiscard]] IntersectionInformation rayCast(const Vec3D &from, const Vec3D &to,
                                                   const std::set<ObjectTag> &skipTags = {}) const;
@@ -45,4 +48,4 @@ public:
 };
 
 
-#endif //INC_3DZAVR_TEST_GROUP_H
+#endif //ENGINE_GROUP_H

--- a/engine/objects/geometry/Bounds.h
+++ b/engine/objects/geometry/Bounds.h
@@ -1,0 +1,15 @@
+//
+// Created by Neiro on 28.2.2024.
+//
+
+#ifndef ENGINE_BOUNDS_H
+#define ENGINE_BOUNDS_H
+
+#include <linalg/Vec3D.h>
+
+struct Bounds {
+    Vec3D center;
+    Vec3D extents;
+};
+
+#endif //ENGINE_BOUNDS_H

--- a/engine/objects/geometry/Mesh.cpp
+++ b/engine/objects/geometry/Mesh.cpp
@@ -5,7 +5,6 @@
 #include <utility>
 
 #include "Mesh.h"
-#include "utils/ResourceManager.h"
 #include "Plane.h"
 
 Mesh &Mesh::operator*=(const Matrix4x4 &matrix4X4) {
@@ -20,15 +19,17 @@ Mesh &Mesh::operator*=(const Matrix4x4 &matrix4X4) {
 }
 
 Mesh::Mesh(const ObjectTag& tag, const std::vector<Triangle> &tries, std::shared_ptr<Material> material) :
-Object(tag), _tris(tries), _material(material) {}
+    Object(tag), _tris(tries), _material(std::move(material)) {
+    calculateBounds();
+}
 
-Mesh Mesh::Surface(const ObjectTag &tag, double w, double h, std::shared_ptr<Material> material) {
+Mesh Mesh::Surface(const ObjectTag &tag, double w, double h, const std::shared_ptr<Material>& material) {
     Mesh surface(tag);
 
-    surface._tris = {
+    surface.setTriangles(std::move(std::vector<Triangle>{
             { {Vec4D{w/2, 0.0, h/2, 1.0}, Vec4D{w/2, 0.0, -h/2, 1.0}, Vec4D{-w/2, 0.0, -h/2, 1.0}}, {Vec3D{0, 0, 1}, Vec3D{0, 1, 1}, Vec3D{1, 1, 1}} },
             { {Vec4D{-w/2, 0.0, -h/2, 1.0}, Vec4D{-w/2, 0.0, h/2, 1.0}, Vec4D{w/2, 0.0, h/2, 1.0}}, {Vec3D{1, 1, 1}, Vec3D{1, 0, 1}, Vec3D{0, 0, 1}} }
-    };
+    }));
     if(material) {
         surface.setMaterial(material);
     }
@@ -39,7 +40,7 @@ Mesh Mesh::Surface(const ObjectTag &tag, double w, double h, std::shared_ptr<Mat
 Mesh Mesh::Cube(const ObjectTag &tag, double size) {
     Mesh cube(tag);
 
-    cube._tris = {
+    cube.setTriangles(std::move(std::vector<Triangle>{
             { {Vec4D{0.0, 0.0, 0.0, 1.0},    Vec4D{0.0, 1.0, 0.0, 1.0},    Vec4D{1.0, 1.0, 0.0, 1.0}} },
             { {Vec4D{0.0, 0.0, 0.0, 1.0},    Vec4D{1.0, 1.0, 0.0, 1.0},    Vec4D{1.0, 0.0, 0.0, 1.0}} },
             { {Vec4D{1.0, 0.0, 0.0, 1.0},    Vec4D{1.0, 1.0, 0.0, 1.0},    Vec4D{1.0, 1.0, 1.0, 1.0}} },
@@ -52,7 +53,7 @@ Mesh Mesh::Cube(const ObjectTag &tag, double size) {
             { {Vec4D{0.0, 1.0, 0.0, 1.0},    Vec4D{1.0, 1.0, 1.0, 1.0},    Vec4D{1.0, 1.0, 0.0, 1.0}} },
             { {Vec4D{1.0, 0.0, 1.0, 1.0},    Vec4D{0.0, 0.0, 1.0, 1.0},    Vec4D{0.0, 0.0, 0.0, 1.0}} },
             { {Vec4D{1.0, 0.0, 1.0, 1.0},    Vec4D{0.0, 0.0, 0.0, 1.0},    Vec4D{1.0, 0.0, 0.0, 1.0}} },
-    };
+    }));
 
     return cube *= Matrix4x4::Scale(Vec3D(size, size, size))*Matrix4x4::Translation(Vec3D(-0.5, -0.5, -0.5));
 }
@@ -77,7 +78,7 @@ Mesh Mesh::LineTo(const ObjectTag &tag, const Vec3D &from, const Vec3D &to, doub
     Vec4D p8 = (to - from + v2 * line_width / 2.0 - v3 * line_width / 2.0).makePoint4D();
 
 
-    line._tris = std::move(std::vector<Triangle>{
+    line.setTriangles(std::move(std::vector<Triangle>{
             {{p2, p4, p1}},
             {{p2, p3, p4}},
             {{p1, p6, p2}},
@@ -90,7 +91,7 @@ Mesh Mesh::LineTo(const ObjectTag &tag, const Vec3D &from, const Vec3D &to, doub
             {{p4, p7, p8}},
             {{p1, p8, p5}},
             {{p1, p4, p8}}
-    });
+    }));
     line.translateToPoint(from);
 
     return line;
@@ -126,7 +127,7 @@ Mesh Mesh::ArrowTo(const ObjectTag &tag, const Vec3D &from, const Vec3D &to, dou
 
     Vec4D p13 = (to - from).makePoint4D();
 
-    arrow._tris = std::move(std::vector<Triangle>{
+    arrow.setTriangles(std::move(std::vector<Triangle>{
             {{p2, p4, p1}},
             {{p2, p3, p4}},
             {{p1, p6, p2}},
@@ -144,7 +145,7 @@ Mesh Mesh::ArrowTo(const ObjectTag &tag, const Vec3D &from, const Vec3D &to, dou
             {{ p10, p11, p13 }},
             {{ p11, p12, p13 }},
             {{ p12, p9, p13  }},
-    });
+    }));
     arrow.translateToPoint(from);
 
     return arrow;
@@ -152,10 +153,7 @@ Mesh Mesh::ArrowTo(const ObjectTag &tag, const Vec3D &from, const Vec3D &to, dou
 
 void Mesh::setTriangles(std::vector<Triangle>&& t) {
     _tris = std::move(t);
-}
-
-Mesh::~Mesh() {
-    _tris.clear();
+    calculateBounds();
 }
 
 Object::IntersectionInformation Mesh::intersect(const Vec3D &from, const Vec3D &to) {
@@ -231,6 +229,24 @@ void Mesh::copyTriangles(const Mesh &mesh, bool deepCopy) {
     } else {
         _tris = mesh._tris;
     }
+    _bounds = mesh._bounds;
+}
+
+void Mesh::calculateBounds() {
+    Vec3D min = _tris.empty() ? Vec3D() : Vec3D(_tris[0][0]);
+    Vec3D max = min;
+    for (const auto & t : _tris) {
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 3; j++) {
+                min[j] = std::min(min[i], t[i][j]);
+                max[j] = std::max(max[i], t[i][j]);
+            }
+        }
+    }
+    _bounds = Bounds {
+        .center = (max + min) / 2,
+        .extents = (max - min) / 2
+    };
 }
 
 Mesh::Mesh(const Mesh &mesh, bool deepCopy) :

--- a/engine/objects/geometry/Mesh.cpp
+++ b/engine/objects/geometry/Mesh.cpp
@@ -185,8 +185,8 @@ Object::IntersectionInformation Mesh::intersect(const Vec3D &from, const Vec3D &
             continue;
         }
 
-        auto trianglePlane = std::make_shared<Plane>(tri, ObjectTag(""));
-        auto intersection = trianglePlane->intersect(from_model, to_model);
+        auto trianglePlane = Plane(tri);
+        auto intersection = trianglePlane.intersect(from_model, to_model);
 
         if (intersection.distanceToObject > 0 && tri.isPointInside(intersection.pointOfIntersection)) {
 
@@ -194,8 +194,8 @@ Object::IntersectionInformation Mesh::intersect(const Vec3D &from, const Vec3D &
             // Due-to this effect if you scale some object in x times you will get distance in x times smaller.
             // That's why we need to perform distance calculation in the global coordinate system where metric
             // is the same for all objects.
-            trianglePlane = std::make_shared<Plane>(tri*model, ObjectTag(""));
-            auto globalIntersection = trianglePlane->intersect(from, to);
+            trianglePlane = Plane(model * tri.norm(), Vec3D(model * tri[0]));
+            auto globalIntersection = trianglePlane.intersect(from, to);
             double globalDistance = (globalIntersection.pointOfIntersection - from).abs();
 
             if(globalDistance < minDistance) {

--- a/engine/objects/geometry/Mesh.cpp
+++ b/engine/objects/geometry/Mesh.cpp
@@ -238,8 +238,8 @@ void Mesh::calculateBounds() {
     for (const auto & t : _tris) {
         for (int i = 0; i < 3; i++) {
             for (int j = 0; j < 3; j++) {
-                min[j] = std::min(min[i], t[i][j]);
-                max[j] = std::max(max[i], t[i][j]);
+                min[j] = std::min(min[j], t[i][j]);
+                max[j] = std::max(max[j], t[i][j]);
             }
         }
     }

--- a/engine/objects/geometry/Mesh.h
+++ b/engine/objects/geometry/Mesh.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include <objects/geometry/Triangle.h>
+#include <objects/geometry/Bounds.h>
 #include <objects/Object.h>
 #include <io/Image.h>
 #include <objects/props/Material.h>
@@ -17,12 +18,14 @@ class Mesh : public Object {
 private:
     std::vector<Triangle> _tris;
     std::shared_ptr<Material> _material = nullptr;
+    Bounds _bounds;
 
     bool _visible = true;
 
     Mesh &operator*=(const Matrix4x4 &matrix4X4);
 
     void copyTriangles(const Mesh& mesh, bool deepCopy);
+    void calculateBounds();
 
 public:
     explicit Mesh(const ObjectTag& nameTag) : Object(nameTag) {};
@@ -40,7 +43,9 @@ public:
     [[nodiscard]] size_t size() const { return _tris.size() * 3; }
 
     [[nodiscard]] std::shared_ptr<Material> getMaterial() const { return _material; }
-    void setMaterial(std::shared_ptr<Material> material) { _material = material; }
+    void setMaterial(std::shared_ptr<Material> material) { _material = std::move(material); }
+
+    [[nodiscard]] const Bounds& bounds() const { return _bounds; }
 
     void setVisible(bool visibility) { _visible = visibility; }
 
@@ -48,13 +53,11 @@ public:
 
     [[nodiscard]] IntersectionInformation intersect(const Vec3D &from, const Vec3D &to) override;
 
-    ~Mesh();
-
     std::shared_ptr<Object> copy(const ObjectTag& tag) const override {
         return std::make_shared<Mesh>(tag, *this);
     }
 
-    Mesh static Surface(const ObjectTag &tag, double width, double height, std::shared_ptr<Material> material = nullptr);
+    Mesh static Surface(const ObjectTag &tag, double width, double height, const std::shared_ptr<Material>& material = nullptr);
     Mesh static Cube(const ObjectTag &tag, double size = 1.0);
     Mesh static LineTo(const ObjectTag &tag, const Vec3D &from, const Vec3D &to, double line_width = 0.1);
     Mesh static ArrowTo(const ObjectTag &tag, const Vec3D& from, const Vec3D& to, double line_width = 1);

--- a/engine/objects/geometry/Plane.h
+++ b/engine/objects/geometry/Plane.h
@@ -11,32 +11,34 @@
 #include "utils/stack_vector.h"
 
 
-class Plane final : public Object {
+class Plane final {
 private:
-    const Vec3D _normal;
-    const Vec3D _point;
+    struct IntersectionInformation final {
+        Vec3D pointOfIntersection;
+        double distanceToObject = std::numeric_limits<double>::infinity();
+        double k = 0;
+        bool intersected = false;
+    };
 public:
-    Plane() = delete;
+    Vec3D normal;
+    double offset;
 
+    Plane();
     Plane(const Plane &plane) = default;
-    Plane(const ObjectTag& tag, const Plane &plane);
 
     // You can define plane by defining the points in 3D space
-    explicit Plane(const Triangle &tri, const ObjectTag& nameTag, const Color& color = Consts::WHITE_COLORS[2]);
+    explicit Plane(const Triangle &tri);
 
     // Or by defining normal vector and one val laying on the plane
-    Plane(const Vec3D &N, const Vec3D &P, const ObjectTag& nameTag, const Color& color = Consts::WHITE_COLORS[2]);
+    Plane(const Vec3D &normal, const Vec3D &point);
+    Plane(const Vec3D &normal, double offset);
+
+    Plane& operator=(const Plane &plane) = default;
 
     [[nodiscard]] double distance(const Vec3D &point4D) const;
-    [[nodiscard]] IntersectionInformation intersect(const Vec3D &from, const Vec3D &to) override;
+    [[nodiscard]] IntersectionInformation intersect(const Vec3D &from, const Vec3D &to) const;
     [[nodiscard]] stack_vector<Triangle, 2> clip(const Triangle &tri) const;
-    [[nodiscard]] Vec3D N() const { return _normal; }
-    [[nodiscard]] Vec3D P() const { return _point; }
-
-    std::shared_ptr<Object> copy(const ObjectTag& tag) const override {
-        return std::make_shared<Plane>(tag, *this);
-    }
 };
 
 
-#endif //INC_3DZAVR_PLANE_H
+#endif //ENGINE_PLANE_H


### PR DESCRIPTION
- enable LTO in CMake
- reduce indirection, allocations and Plane overhead
- clip triangles in world space to reduce matrix multiplications
- subtract EPS from Plane offset to fix transparent pixels at the edge of the screen
- add Alix-Aligned Bounding Box to Mesh to check bounds visibility before checking all triangles