### PR TITLE
SDL fix and sample index caching

### DIFF
--- a/engine/Engine.cpp
+++ b/engine/Engine.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <mach/mach.h>
 
 #include <Engine.h>
 #include <utils/Time.h>

--- a/engine/io/Screen.cpp
+++ b/engine/io/Screen.cpp
@@ -293,6 +293,7 @@ void Screen::drawTriangle(const Triangle &triangle, Material *material) {
         Vec3D uv_hom_x_avr = uv_hom_origin + uv_hom_dy*(y-y_min) + uv_hom_dx*((x_cur_min+x_cur_max)/2 - x_min);
         Vec2D uv_dehom_x_avr(uv_hom_x_avr.x() / uv_hom_x_avr.z(), uv_hom_x_avr.y() / uv_hom_x_avr.z());
         double area = areaDuDv(uv_hom_x_avr, uv_dehom_x_avr, uv_hom_dx, uv_hom_dy, (x_min+x_max)/2, y, x_min, y_min, texture->width(), texture->height());
+        uint16_t sample = texture->get_sample_index(area);
 
         for (uint16_t x = x_cur_min; x <= x_cur_max; x++) {
             if (texture) {
@@ -303,7 +304,8 @@ void Screen::drawTriangle(const Triangle &triangle, Material *material) {
                  * Instead, we use averaged area for the horizontal line (calculation is above).
                 */
                 //double area = areaDuDv(uv_hom, uv_dehom, uv_hom_dx, uv_hom_dy, x, y, x_min, y_min, texture->width(), texture->height());
-                color = texture->get_pixel_from_UV(uv_dehom, area);
+                //color = texture->get_pixel_from_UV(uv_dehom, area);
+                color = texture->get_pixel_from_sample_UV(uv_dehom, sample);
             }
             double z = triangle[0].z() * abg.x() + triangle[1].z() * abg.y() + triangle[2].z() * abg.z();
             drawPixelUnsafe(x, y, z, color);

--- a/engine/objects/props/Texture.cpp
+++ b/engine/objects/props/Texture.cpp
@@ -18,7 +18,7 @@ Color Texture::get_pixel_from_UV(const Vec2D &uv) const {
     return _texture.front().get_pixel_from_UV(uv);
 }
 
-Color Texture::get_pixel_from_UV(const Vec2D &uv, double area) const {
+uint16_t Texture::get_sample_index(double area) const {
     uint64_t limit = 1ULL << (_texture.size() - 1);
     uint16_t K;
 
@@ -29,6 +29,14 @@ Color Texture::get_pixel_from_UV(const Vec2D &uv, double area) const {
     } else {
         K = _texture.size() - 1;
     }
+    return K;
+}
 
-    return _texture[K].get_pixel_from_UV(uv);
+Color Texture::get_pixel_from_sample_UV(const Vec2D& uv, uint16_t sample) const {
+    return _texture[sample].get_pixel_from_UV(uv);
+}
+
+Color Texture::get_pixel_from_UV(const Vec2D &uv, double area) const {
+    uint16_t sample = get_sample_index(area);
+    return get_pixel_from_sample_UV(uv, sample);
 }

--- a/engine/objects/props/Texture.h
+++ b/engine/objects/props/Texture.h
@@ -19,6 +19,8 @@ public:
     [[nodiscard]] Color get_pixel_from_UV(const Vec2D& uv) const;
 
     // For resampling
+    [[nodiscard]] uint16_t get_sample_index(double area) const;
+    [[nodiscard]] Color get_pixel_from_sample_UV(const Vec2D& uv, uint16_t sample) const;
     [[nodiscard]] Color get_pixel_from_UV(const Vec2D& uv, double area) const;
 
     [[nodiscard]] uint16_t width() const { return _texture.front().width(); }


### PR DESCRIPTION
- reuse sample index calculation
- remove `<mach/mach.h>` from Engine.cpp