### PR TITLE
SDL optimizations

### DIFF
--- a/engine/Engine.cpp
+++ b/engine/Engine.cpp
@@ -27,15 +27,13 @@ void Engine::projectGroup(const Group &group) {
 
             if(!isTransparent) {
                 for(const auto& t: projected) {
-                    _projectedOpaqueTriangles.emplace_back(t, material);
+                    _projectedOpaqueTriangles.emplace_back(t, material.get());
                 }
             } else {
                 for(const auto& t: projected) {
-                    _projectedTranspTriangles.emplace_back(t, material);
+                    _projectedTranspTriangles.emplace_back(t, material.get());
                 }
             }
-
-            continue;
         }
         std::shared_ptr<Group> subGroup = std::dynamic_pointer_cast<Group>(obj);
         if(subGroup) {
@@ -45,8 +43,7 @@ void Engine::projectGroup(const Group &group) {
     }
 }
 
-void
-Engine::drawProjectedTriangles() {
+void Engine::drawProjectedTriangles() {
 
     Time::startTimer("d sort triangles");
     /*
@@ -59,8 +56,8 @@ Engine::drawProjectedTriangles() {
     });
     */
     std::sort(_projectedTranspTriangles.begin(), _projectedTranspTriangles.end(), [](const auto& e1, const auto& e2){
-        Triangle t1(e1.first);
-        Triangle t2(e2.first);
+        const Triangle& t1 = e1.first;
+        const Triangle& t2 = e2.first;
         double z1 = t1[0].z() + t1[1].z() + t1[2].z();
         double z2 = t2[0].z() + t2[1].z() + t2[2].z();
         return z1 > z2;
@@ -69,10 +66,10 @@ Engine::drawProjectedTriangles() {
 
     Time::startTimer("d rasterization");
     for (const auto& [triangle, material]: _projectedOpaqueTriangles) {
-        screen->drawTriangle(triangle, material.get());
+        screen->drawTriangle(triangle, material);
     }
     for (const auto& [triangle, material]: _projectedTranspTriangles) {
-        screen->drawTriangle(triangle, material.get());
+        screen->drawTriangle(triangle, material);
     }
     Time::stopTimer("d rasterization");
 }

--- a/engine/Engine.h
+++ b/engine/Engine.h
@@ -24,8 +24,8 @@ private:
     bool _updateWorld = true;
     [[maybe_unused]] void projectAndDrawGroup(const Group& group) const;
 
-    std::vector<std::pair<Triangle, std::shared_ptr<Material>>> _projectedOpaqueTriangles;
-    std::vector<std::pair<Triangle, std::shared_ptr<Material>>> _projectedTranspTriangles;
+    std::vector<std::pair<Triangle, Material*>> _projectedOpaqueTriangles;
+    std::vector<std::pair<Triangle, Material*>> _projectedTranspTriangles;
     void projectGroup(const Group& group);
     void drawProjectedTriangles();
 

--- a/engine/io/Screen.cpp
+++ b/engine/io/Screen.cpp
@@ -114,10 +114,13 @@ void Screen::drawPixel(uint16_t x, uint16_t y, double z, const Color &color) {
 }
 
 inline void Screen::drawPixelUnsafe(const uint16_t x, const uint16_t y, const Color &color) {
-    //_pixelBuffer[y * _width + x] = color.rgba();
-    double alpha = color.a()/255.0;
-    Color sumColor = color*alpha + Color(_pixelBuffer[y * _width + x])*(1.0-alpha);
-    _pixelBuffer[y * _width + x] = sumColor.rgba();
+    if (color.a() == 255) {
+        _pixelBuffer[y * _width + x] = color.rgba();
+    } else {
+        double alpha = color.a() / 255.0;
+        Color sumColor = color * alpha + Color(_pixelBuffer[y * _width + x]) * (1.0 - alpha);
+        _pixelBuffer[y * _width + x] = sumColor.rgba();
+    }
 }
 
 inline void Screen::drawPixelUnsafe(uint16_t x, uint16_t y, double z, const Color &color) {

--- a/engine/io/Screen.cpp
+++ b/engine/io/Screen.cpp
@@ -305,7 +305,7 @@ void Screen::drawTriangle(const Triangle &triangle, Material *material) {
         Vec3D uv_hom_x_avr = uv_hom_origin + uv_hom_dy*(y-y_min) + uv_hom_dx*((x_cur_min+x_cur_max)/2 - x_min);
         Vec2D uv_dehom_x_avr(uv_hom_x_avr.x() / uv_hom_x_avr.z(), uv_hom_x_avr.y() / uv_hom_x_avr.z());
         double area = areaDuDv(uv_hom_x_avr, uv_dehom_x_avr, uv_hom_dx, uv_hom_dy, (x_min+x_max)/2, y, x_min, y_min, texture->width(), texture->height());
-        uint16_t sample = texture->get_sample_index(area);
+        const Image& sample = texture->get_sample(area);
 
         for (uint16_t x = x_cur_min; x <= x_cur_max; x++) {
             double z = triangle[0].z() * abg.x() + triangle[1].z() * abg.y() + triangle[2].z() * abg.z();
@@ -318,7 +318,7 @@ void Screen::drawTriangle(const Triangle &triangle, Material *material) {
                 */
                 //double area = areaDuDv(uv_hom, uv_dehom, uv_hom_dx, uv_hom_dy, x, y, x_min, y_min, texture->width(), texture->height());
                 //color = texture->get_pixel_from_UV(uv_dehom, area);
-                color = texture->get_pixel_from_sample_UV(uv_dehom, sample);
+                color = sample.get_pixel_from_UV(uv_dehom);
 
                 drawPixelUnsafe(x, y, z, color*material->d());
             }

--- a/engine/io/Screen.cpp
+++ b/engine/io/Screen.cpp
@@ -262,8 +262,14 @@ void Screen::drawTriangle(const Triangle &triangle, Material *material) {
     //drawLine(Vec2D(triangle[2]), Vec2D(triangle[0]), Consts::BLACK);
 
     if (material == nullptr || material->texture() == nullptr) {
-        Color color = material ? material->ambient() : Consts::RED;
-        drawTriangle(triangle, color * material->d());
+        Color color;
+        if (material == nullptr) {
+            color = Consts::RED;
+        } else {
+            color = material->ambient();
+            color[3] *= material->d();
+        }
+        drawTriangle(triangle, color);
         return;
     }
 
@@ -319,8 +325,8 @@ void Screen::drawTriangle(const Triangle &triangle, Material *material) {
                 //double area = areaDuDv(uv_hom, uv_dehom, uv_hom_dx, uv_hom_dy, x, y, x_min, y_min, texture->width(), texture->height());
                 //color = texture->get_pixel_from_UV(uv_dehom, area);
                 color = sample.get_pixel_from_UV(uv_dehom);
-
-                drawPixelUnsafe(x, y, z, color*material->d());
+                color[3] *= material->d();
+                drawPixelUnsafe(x, y, z, color);
             }
             abg += abg_dx;
             uv_hom += uv_hom_dx;

--- a/engine/objects/props/Color.h
+++ b/engine/objects/props/Color.h
@@ -31,6 +31,9 @@ public:
     [[nodiscard]] inline uint8_t b() const { return _c[2]; }
     [[nodiscard]] inline uint8_t a() const { return _c[3]; }
 
+    [[nodiscard]] inline uint8_t& operator[](std::size_t i) { return _c[i]; }
+    [[nodiscard]] inline const uint8_t& operator[](std::size_t i) const { return _c[i]; }
+
     [[nodiscard]] inline uint32_t rgba() const { return (_c[0] << 24) | (_c[1] << 16) | (_c[2] << 8) | _c[3]; }
 
     // Operations with colors

--- a/engine/objects/props/Color.h
+++ b/engine/objects/props/Color.h
@@ -48,6 +48,19 @@ public:
                                                                                   g()+other.g(),
                                                                                   b()+other.b(),
                                                                                   a()+other.a()); };
+
+    [[nodiscard]] inline Color blend(const Color& other) const {
+        // default SDL blend mode:
+        // dstRGB = (srcRGB * srcA) + (dstRGB * (1-srcA))
+        // dstA = srcA + (dstA * (1-srcA))
+        uint8_t ra = 255 - a();
+        return Color(
+            (static_cast<uint16_t>(r()) * a() + other.r() * ra) / 255,
+            (static_cast<uint16_t>(g()) * a() + other.g() * ra) / 255,
+            (static_cast<uint16_t>(b()) * a() + other.b() * ra) / 255,
+            (static_cast<uint16_t>(a()) * 255 + other.a() * ra) / 255
+        );
+    }
 };
 
 

--- a/engine/objects/props/Texture.cpp
+++ b/engine/objects/props/Texture.cpp
@@ -31,7 +31,7 @@ Color Texture::get_pixel_from_UV(const Vec2D &uv) const {
     return _texture.front().get_pixel_from_UV(uv);
 }
 
-uint16_t Texture::get_sample_index(double area) const {
+const Image& Texture::get_sample(double area) const {
     uint64_t limit = 1ULL << (_texture.size() - 1);
     uint16_t K;
 
@@ -42,14 +42,9 @@ uint16_t Texture::get_sample_index(double area) const {
     } else {
         K = _texture.size() - 1;
     }
-    return K;
-}
-
-Color Texture::get_pixel_from_sample_UV(const Vec2D& uv, uint16_t sample) const {
-    return _texture[sample].get_pixel_from_UV(uv);
+    return _texture[K];
 }
 
 Color Texture::get_pixel_from_UV(const Vec2D &uv, double area) const {
-    uint16_t sample = get_sample_index(area);
-    return get_pixel_from_sample_UV(uv, sample);
+    return get_sample(area).get_pixel_from_UV(uv);
 }

--- a/engine/objects/props/Texture.h
+++ b/engine/objects/props/Texture.h
@@ -21,8 +21,7 @@ public:
     [[nodiscard]] Color get_pixel_from_UV(const Vec2D& uv) const;
 
     // For resampling
-    [[nodiscard]] uint16_t get_sample_index(double area) const;
-    [[nodiscard]] Color get_pixel_from_sample_UV(const Vec2D& uv, uint16_t sample) const;
+    [[nodiscard]] const Image& get_sample(double area) const;
     [[nodiscard]] Color get_pixel_from_UV(const Vec2D& uv, double area) const;
 
     [[nodiscard]] uint16_t width() const { return _texture.front().width(); }


### PR DESCRIPTION
- use simple drawTriangle if there is no texture
- store plain pointer to Material to reduce memory footprint
- use const ref instead of copy
- use const ref to sample instead of sample index
- fix usage of material alpha
- add alpha check to prevent heavy color calculations (should be fine unless we have texture with mix of fully and partially opaque pixels)