### PR TITLE
Fix error on linux

### DIFF
--- a/engine/utils/monitoring.cpp
+++ b/engine/utils/monitoring.cpp
@@ -13,6 +13,7 @@ int getProcessSizeMB() {
 }
 #elif defined(__linux__)
 #include <unistd.h>
+#include <fstream>
 int getProcessSizeMB() {
     std::ifstream statmFile("/proc/self/statm");
     long pageSizeMB = sysconf(_SC_PAGESIZE) / Consts::MB;


### PR DESCRIPTION
Fix implicit instantiation of undefined template 'std::basic_ifstream<char>' at line 17